### PR TITLE
Deprecate Types and methods not supported or deprecated in NUnit 3

### DIFF
--- a/src/NUnitFramework/framework/Assert.cs
+++ b/src/NUnitFramework/framework/Assert.cs
@@ -2072,6 +2072,7 @@ namespace NUnit.Framework
         /// <param name="aString">The string to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
+        [Obsolete("Use Constraint syntax")]
         public static void IsNullOrEmpty(string aString, string message, params object[] args)
         {
             Assert.That(aString, new NullOrEmptyStringConstraint(), message, args);
@@ -2081,6 +2082,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="aString">The string to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
+        [Obsolete("Use Constraint syntax")]
         public static void IsNullOrEmpty(string aString, string message)
         {
             Assert.That(aString, new NullOrEmptyStringConstraint(), message, null);
@@ -2089,6 +2091,7 @@ namespace NUnit.Framework
         /// Assert that a string is either null or equal to string.Empty
         /// </summary>
         /// <param name="aString">The string to be tested</param>
+        [Obsolete("Use Constraint syntax")]
         public static void IsNullOrEmpty(string aString)
         {
             Assert.That(aString, new NullOrEmptyStringConstraint(), null, null);
@@ -2104,6 +2107,7 @@ namespace NUnit.Framework
         /// <param name="aString">The string to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
         /// <param name="args">Array of objects to be used in formatting the message</param>
+        [Obsolete("Use Constraint syntax")]
         public static void IsNotNullOrEmpty(string aString, string message, params object[] args)
         {
             Assert.That(aString, new NotConstraint(new NullOrEmptyStringConstraint()), message, args);
@@ -2113,6 +2117,7 @@ namespace NUnit.Framework
         /// </summary>
         /// <param name="aString">The string to be tested</param>
         /// <param name="message">The message to display in case of failure</param>
+        [Obsolete("Use Constraint syntax")]
         public static void IsNotNullOrEmpty(string aString, string message)
         {
             Assert.That(aString, new NotConstraint(new NullOrEmptyStringConstraint()), message, null);
@@ -2121,6 +2126,7 @@ namespace NUnit.Framework
         /// Assert that a string is not null or empty
         /// </summary>
         /// <param name="aString">The string to be tested</param>
+        [Obsolete("Use Constraint syntax")]
         public static void IsNotNullOrEmpty(string aString)
         {
             Assert.That(aString, new NotConstraint(new NullOrEmptyStringConstraint()), null, null);

--- a/src/NUnitFramework/framework/AssertionHelper.cs
+++ b/src/NUnitFramework/framework/AssertionHelper.cs
@@ -18,6 +18,7 @@ namespace NUnit.Framework
 	/// <see cref="Is"/>, from which it inherits much of its
 	/// behavior, in certain mock object frameworks.
 	/// </summary>
+    [Obsolete("Not supported in NUnit 3")]
 	public class AssertionHelper : ConstraintFactory
     {
         #region Assert

--- a/src/NUnitFramework/framework/Attributes/ExpectedExceptionAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ExpectedExceptionAttribute.cs
@@ -27,7 +27,7 @@ namespace NUnit.Framework
 	/// </summary>
 	/// 
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=false)]
-    [Obsolete("Not supportd in NUnit 3")]
+    [Obsolete("Use Assert.Throw")]
 	public class ExpectedExceptionAttribute : Attribute
 	{
 		private Type expectedException;

--- a/src/NUnitFramework/framework/Attributes/ExpectedExceptionAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/ExpectedExceptionAttribute.cs
@@ -27,6 +27,7 @@ namespace NUnit.Framework
 	/// </summary>
 	/// 
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=false)]
+    [Obsolete("Not supportd in NUnit 3")]
 	public class ExpectedExceptionAttribute : Attribute
 	{
 		private Type expectedException;

--- a/src/NUnitFramework/framework/Attributes/RequiredAddinAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/RequiredAddinAttribute.cs
@@ -15,6 +15,7 @@ namespace NUnit.Framework
     /// as NotRunnable.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly,AllowMultiple=true, Inherited=false)]
+    [Obsolete("Not supported in NUnit 3")]
     public class RequiredAddinAttribute : Attribute
     {
         private string requiredAddin;

--- a/src/NUnitFramework/framework/Attributes/SuiteAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/SuiteAttribute.cs
@@ -13,6 +13,7 @@ namespace NUnit.Framework
 	/// that returns a list of tests.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Property, AllowMultiple=false, Inherited=false)]
+    [Obsolete("Not supported in NUnit 3")]
 	public class SuiteAttribute : Attribute
 	{}
 }

--- a/src/NUnitFramework/framework/Attributes/TestFixtureSetUpAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureSetUpAttribute.cs
@@ -13,6 +13,7 @@ namespace NUnit.Framework
 	/// called before any tests in a fixture are run.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
+    [Obsolete("Use OneTimeSetUpAttribute")]
 	public class TestFixtureSetUpAttribute : Attribute
 	{
 	}

--- a/src/NUnitFramework/framework/Attributes/TestFixtureTearDownAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/TestFixtureTearDownAttribute.cs
@@ -14,6 +14,7 @@ namespace NUnit.Framework
 	/// guaranteed to be called, even if an exception is thrown.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
+    [Obsolete("Use OneTimeTearDownAttribute")]
 	public class TestFixtureTearDownAttribute : Attribute
 	{
 	}

--- a/src/NUnitFramework/framework/Attributes/ThreadingAttributes.cs
+++ b/src/NUnitFramework/framework/Attributes/ThreadingAttributes.cs
@@ -34,6 +34,7 @@ namespace NUnit.Framework
     /// to serve the same purpose.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
+    [Obsolete("Use ApartmentAttribute")]
     public class RequiresSTAAttribute : PropertyAttribute
     {
         /// <summary>
@@ -53,6 +54,7 @@ namespace NUnit.Framework
     /// to serve the same purpose.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited=false)]
+    [Obsolete("Use ApartmentAttribute")]
     public class RequiresMTAAttribute : PropertyAttribute
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Constraints/NullOrEmptyStringConstraint.cs
+++ b/src/NUnitFramework/framework/Constraints/NullOrEmptyStringConstraint.cs
@@ -11,6 +11,7 @@ namespace NUnit.Framework.Constraints
     /// <summary>
     /// NullEmptyStringConstraint tests whether a string is either null or empty.
     /// </summary>
+    [Obsolete("Use Constraint syntax")]
     public class NullOrEmptyStringConstraint : Constraint
     {
         /// <summary>

--- a/src/NUnitFramework/framework/Is.cs
+++ b/src/NUnitFramework/framework/Is.cs
@@ -421,6 +421,7 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value contains the substring supplied as an argument.
         /// </summary>
+        [Obsolete("Use Does.Contain")]
         public static SubstringConstraint StringContaining(string expected)
         {
             return new SubstringConstraint(expected);
@@ -434,6 +435,7 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value starts with the substring supplied as an argument.
         /// </summary>
+        [Obsolete("Use Does.StartWith")]
         public static StartsWithConstraint StringStarting(string expected)
         {
             return new StartsWithConstraint(expected);
@@ -447,6 +449,7 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value ends with the substring supplied as an argument.
         /// </summary>
+        [Obsolete("Use Does.EndWith")]
         public static EndsWithConstraint StringEnding(string expected)
         {
             return new EndsWithConstraint(expected);
@@ -460,6 +463,7 @@ namespace NUnit.Framework
         /// Returns a constraint that succeeds if the actual
         /// value matches the regular expression supplied as an argument.
         /// </summary>
+        [Obsolete("Use Does.Match")]
         public static RegexConstraint StringMatching(string pattern)
         {
             return new RegexConstraint(pattern);


### PR DESCRIPTION
Fixes #2 

This adds `ObsoleteAttribute` to various Types and methods, as listed in the issue.

Note that some of the recommended replacements for the deprecated code do not yet exist in the codebase, because they are being handled as separate issues. None of the new attributes cause an error but only give warning messages.