### PR TITLE
Add Does class

### DIFF
--- a/src/NUnitFramework/framework/Does.cs
+++ b/src/NUnitFramework/framework/Does.cs
@@ -1,0 +1,100 @@
+﻿// ***********************************************************************
+// Copyright (c) 2014 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// Helper class with properties and methods that supply
+    /// a number of constraints used in Asserts.
+    /// </summary>
+    public static class Does
+    {
+        #region Not
+
+        /// <summary>
+        /// Returns a ConstraintExpression that negates any
+        /// following constraint.
+        /// </summary>
+        public static ConstraintExpression Not
+        {
+            get { return new ConstraintExpression().Not; }
+        }
+
+        #endregion
+
+        #region Contain
+
+        /// <summary>
+        /// Returns a new <see cref="ContainsConstraint"/>. This constraint
+        /// will, in turn, make use of the appropriate second-level
+        /// constraint, depending on the type of the actual argument.
+        /// </summary>
+        public static SubstringConstraint Contain(string expected)
+        {
+            return new SubstringConstraint(expected);
+        }
+
+        #endregion
+
+        #region StartWith
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value starts with the substring supplied as an argument.
+        /// </summary>
+        public static StartsWithConstraint StartWith(string expected)
+        {
+            return new StartsWithConstraint(expected);
+        }
+
+        #endregion
+
+        #region EndWith
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value ends with the substring supplied as an argument.
+        /// </summary>
+        public static EndsWithConstraint EndWith(string expected)
+        {
+            return new EndsWithConstraint(expected);
+        }
+
+        #endregion
+
+        #region Match
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value matches the regular expression supplied as an argument.
+        /// </summary>
+        public static RegexConstraint Match(string pattern)
+        {
+            return new RegexConstraint(pattern);
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitFramework/framework/nunit.framework.build
+++ b/src/NUnitFramework/framework/nunit.framework.build
@@ -54,6 +54,7 @@
         <include name="CollectionAssert.cs"/>
         <include name="Contains.cs"/>
         <include name="DirectoryAssert.cs"/>
+        <include name="Does.cs"/>
         <include name="FileAssert.cs"/>
         <include name="GlobalSettings.cs"/>
         <include name="Guard.cs"/>

--- a/src/NUnitFramework/framework/nunit.framework.dll.csproj
+++ b/src/NUnitFramework/framework/nunit.framework.dll.csproj
@@ -235,6 +235,7 @@
     <Compile Include="Constraints\XmlSerializableConstraint.cs" />
     <Compile Include="Contains.cs" />
     <Compile Include="DirectoryAssert.cs" />
+    <Compile Include="Does.cs" />
     <Compile Include="Exceptions\AssertionException.cs" />
     <Compile Include="Exceptions\IgnoreException.cs" />
     <Compile Include="Exceptions\InconclusiveException.cs" />

--- a/src/NUnitFramework/tests/StringAssertTests.cs
+++ b/src/NUnitFramework/tests/StringAssertTests.cs
@@ -4,6 +4,8 @@
 // obtain a copy of the license at http://nunit.org.
 // ****************************************************************
 
+using System;
+
 namespace NUnit.Framework.Tests
 {
 	[TestFixture]
@@ -17,7 +19,7 @@ namespace NUnit.Framework.Tests
 			StringAssert.Contains( "abc", "**abc**" );
 		}
 
-        [Test, ExpectedException(typeof(AssertionException))]
+        [Test, ExpectedException(typeof(AssertionException)), Obsolete]
 		public void ContainsFails()
 		{
             expectedMessage =

--- a/src/NUnitFramework/tests/Syntax/StringConstraints.cs
+++ b/src/NUnitFramework/tests/Syntax/StringConstraints.cs
@@ -8,6 +8,7 @@ using System;
 
 namespace NUnit.Framework.Syntax
 {
+    [Obsolete]
     public class SubstringTest : SyntaxTest
     {
         [SetUp]
@@ -33,18 +34,31 @@ namespace NUnit.Framework.Syntax
         }
     }
 
+    public class DoesContain : SyntaxTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            parseTree = @"<substring ""X"">";
+            staticSyntax = Does.Contain("X");
+            inheritedSyntax = Helper().ContainsSubstring("X");
+            builderSyntax = Builder().ContainsSubstring("X");
+        }
+    }
+
     public class SubstringTest_IgnoreCase : SyntaxTest
     {
         [SetUp]
         public void SetUp()
         {
             parseTree = @"<substring ""X"">";
-            staticSyntax = Is.StringContaining("X").IgnoreCase;
+            staticSyntax = Does.Contain("X").IgnoreCase;
             inheritedSyntax = Helper().ContainsSubstring("X").IgnoreCase;
             builderSyntax = Builder().ContainsSubstring("X").IgnoreCase;
         }
     }
 
+    [Obsolete]
     public class StartsWithTest : SyntaxTest
     {
         [SetUp]
@@ -70,18 +84,31 @@ namespace NUnit.Framework.Syntax
         }
     }
 
+    public class DoesStartWithTest : SyntaxTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            parseTree = @"<startswith ""X"">";
+            staticSyntax = Does.StartWith("X");
+            inheritedSyntax = Helper().StartsWith("X");
+            builderSyntax = Builder().StartsWith("X");
+        }
+    }
+
     public class StartsWithTest_IgnoreCase : SyntaxTest
     {
         [SetUp]
         public void SetUp()
         {
             parseTree = @"<startswith ""X"">";
-            staticSyntax = Is.StringStarting("X").IgnoreCase;
+            staticSyntax = Does.StartWith("X").IgnoreCase;
             inheritedSyntax = Helper().StartsWith("X").IgnoreCase;
             builderSyntax = Builder().StartsWith("X").IgnoreCase;
         }
     }
 
+    [Obsolete]
     public class EndsWithTest : SyntaxTest
     {
         [SetUp]
@@ -107,18 +134,31 @@ namespace NUnit.Framework.Syntax
         }
     }
 
+    public class DoesEndWithTest : SyntaxTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            parseTree = @"<endswith ""X"">";
+            staticSyntax = Does.EndWith("X");
+            inheritedSyntax = Helper().EndsWith("X");
+            builderSyntax = Builder().EndsWith("X");
+        }
+    }
+
     public class EndsWithTest_IgnoreCase : SyntaxTest
     {
         [SetUp]
         public void SetUp()
         {
             parseTree = @"<endswith ""X"">";
-            staticSyntax = Is.StringEnding("X").IgnoreCase;
+            staticSyntax = Does.EndWith("X").IgnoreCase;
             inheritedSyntax = Helper().EndsWith("X").IgnoreCase;
             builderSyntax = Builder().EndsWith("X").IgnoreCase;
         }
     }
 
+    [Obsolete]
     public class RegexTest : SyntaxTest
     {
         [SetUp]
@@ -144,13 +184,25 @@ namespace NUnit.Framework.Syntax
         }
     }
 
+    public class DoesMatchTest : SyntaxTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            parseTree = @"<regex ""X"">";
+            staticSyntax = Does.Match("X");
+            inheritedSyntax = Helper().Matches("X");
+            builderSyntax = Builder().Matches("X");
+        }
+    }
+
     public class RegexTest_IgnoreCase : SyntaxTest
     {
         [SetUp]
         public void SetUp()
         {
             parseTree = @"<regex ""X"">";
-            staticSyntax = Is.StringMatching("X").IgnoreCase;
+            staticSyntax = Does.Match("X").IgnoreCase;
             inheritedSyntax = Helper().Matches("X").IgnoreCase;
             builderSyntax = Builder().Matches("X").IgnoreCase;
         }


### PR DESCRIPTION
Fixes #8 

Does.cs added with only string operations, to enable user to follow advice given with deprecated string constraint syntax.